### PR TITLE
Added Battery Icon and Label for three types of watches

### DIFF
--- a/resources-rectangle/layouts/layout.xml
+++ b/resources-rectangle/layouts/layout.xml
@@ -4,4 +4,6 @@
     <label id="DateLabel" x="center" y="50%" font="Graphics.FONT_SMALL" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_LT_GRAY" />
     <label id="MotivationLine1Label" x="center" y="70%" font="Graphics.FONT_SMALL" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_DK_GRAY" />
     <label id="MotivationLine2Label" x="center" y="80%" font="Graphics.FONT_SMALL" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_DK_GRAY" />
+	<label id="BatteryPercentageLabel" x="22%" y="88%" font="Graphics.FONT_TINY" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_WHITE" />
+	<bitmap id="BatteryLogo" x="5%" y="87%" filename="../drawables/batteryIcon.png" />
 </layout>

--- a/resources-semiround/layouts/layout.xml
+++ b/resources-semiround/layouts/layout.xml
@@ -2,6 +2,8 @@
     <bitmap id="FitPotatoLogo" x="center" y="top" filename="../drawables/fit-potato-logo.png" />
     <label id="TimeLabel" x="center" y="30%" font="Graphics.FONT_LARGE" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_LT_GRAY" />
     <label id="DateLabel" x="center" y="50%" font="Graphics.FONT_SMALL" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_LT_GRAY" />
-    <label id="MotivationLine1Label" x="center" y="70%" font="Graphics.FONT_SMALL" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_DK_GRAY" />
-    <label id="MotivationLine2Label" x="center" y="80%" font="Graphics.FONT_MEDIUM" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_DK_GRAY" />
+    <label id="MotivationLine1Label" x="center" y="65%" font="Graphics.FONT_SMALL" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_DK_GRAY" />
+    <label id="MotivationLine2Label" x="center" y="75%" font="Graphics.FONT_MEDIUM" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_DK_GRAY" />
+	<label id="BatteryPercentageLabel" x="55%" y="90%" font="Graphics.FONT_TINY" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_WHITE" />
+	<bitmap id="BatteryLogo" x="38%" y="90%" filename="../drawables/batteryIcon.png" />
 </layout>

--- a/resources/layouts/layout.xml
+++ b/resources/layouts/layout.xml
@@ -2,6 +2,8 @@
     <bitmap id="FitPotatoLogo" x="center" y="top" filename="../drawables/fit-potato-logo.png" />
     <label id="TimeLabel" x="center" y="25%" font="Graphics.FONT_LARGE" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_LT_GRAY" />
     <label id="DateLabel" x="center" y="40%" font="Graphics.FONT_SMALL" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_LT_GRAY" />
-    <label id="MotivationLine1Label" x="center" y="60%" font="Graphics.FONT_SMALL" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_DK_GRAY" />
-    <label id="MotivationLine2Label" x="center" y="70%" font="Graphics.FONT_SMALL" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_DK_GRAY" />
+    <label id="MotivationLine1Label" x="center" y="55%" font="Graphics.FONT_SMALL" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_DK_GRAY" />
+    <label id="MotivationLine2Label" x="center" y="65%" font="Graphics.FONT_SMALL" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_DK_GRAY" />
+	<label id="BatteryPercentageLabel" x="55%" y="80%" font="Graphics.FONT_TINY" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_WHITE" />
+	<bitmap id="BatteryLogo" x="38%" y="81%" filename="../drawables/batteryIcon.png" />
 </layout>

--- a/source/FitPotatoClockView.mc
+++ b/source/FitPotatoClockView.mc
@@ -47,8 +47,14 @@ class FitPotatoClockView extends WatchUi.WatchFace {
         
         var motivationLabel2 = View.findDrawableById("MotivationLine2Label");
         motivationLabel2.setText(motivationLines[1]);
+
+        var batteryPercentageLabel = View.findDrawableById("BatteryPercentageLabel");
+        var clockStats = System.getSystemStats();
+        batteryPercentageLabel.setText(clockStats.battery.toNumber() + "%");
+
         // Call the parent onUpdate function to redraw the layout
         View.onUpdate(dc);
+        
     }
     
     function twelveHour(hour) {


### PR DESCRIPTION
Hi Brian,

I added a couple of icons for the battery for each layout and try to accommodate the battery icon and the percentage for the round, semi-round, and rectangle watches.

I may need to find a couple of additional battery icons and switch depending on the battery level. Right now is just one icon halfway battery